### PR TITLE
Add  feedId, offerId in StatModel

### DIFF
--- a/src/Yandex/Market/Partner/Models/Stat.php
+++ b/src/Yandex/Market/Partner/Models/Stat.php
@@ -14,6 +14,8 @@ class Stat extends Model
     protected $detailedStats;
     protected $offerName;
     protected $url;
+    protected $feedId;
+    protected $offerId;
 
     protected $mappingClasses = [
         'detailedStats' => DetailedStats::class,
@@ -81,5 +83,21 @@ class Stat extends Model
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+    * @return int
+    */
+    public function getFeedId()
+    {
+        return $this->feedId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOfferId()
+    {
+        return $this->offerId;
     }
 }

--- a/tests/Yandex/Tests/Market/Partner/StatisticClientTest.php
+++ b/tests/Yandex/Tests/Market/Partner/StatisticClientTest.php
@@ -192,6 +192,14 @@ class StatisticClientTest extends TestCase
                 $jsonObj->offersStats->offerStats[$i]->url,
                 $offerStat->getUrl()
             );
+            $this->assertEquals(
+                $jsonObj->offersStats->offerStats[$i]->feedId,
+                $offerStat->getFeedId()
+            );
+            $this->assertEquals(
+                $jsonObj->offersStats->offerStats[$i]->offerId,
+                $offerStat->getOfferId()
+            );
         }
     }
 }


### PR DESCRIPTION
1. В версии 2.0 партнерского API Яндекс.Маркета в разделе
"Статистика по предложениям" в выходные данные добавлены поля feedId, offerId.
2. Добавил их поддержку в Stat Model.